### PR TITLE
👷 Fix CI release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,13 @@ on:
     tags:
       - "v*"
 
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to release (e.g. v3.0.0)"
+        required: true
+        type: string
+
 permissions:
   contents: write
   pages: write
@@ -15,6 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
 
       - uses: oven-sh/setup-bun@v2
 
@@ -38,6 +47,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.tag || github.ref }}
           fetch-depth: 0
 
       - name: Download build artifacts
@@ -49,7 +59,11 @@ jobs:
       - name: Generate release notes
         id: notes
         run: |
-          CURRENT_TAG="${GITHUB_REF#refs/tags/}"
+          if [ -n "${{ inputs.tag }}" ]; then
+            CURRENT_TAG="${{ inputs.tag }}"
+          else
+            CURRENT_TAG="${GITHUB_REF#refs/tags/}"
+          fi
           PREV_TAG=$(git tag --sort=-v:refname | grep -v "^${CURRENT_TAG}$" | head -1)
 
           if [ -z "$PREV_TAG" ]; then
@@ -98,6 +112,7 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ inputs.tag || github.ref_name }}
           files: dist/ltmodmenu.user.js
           body: ${{ steps.notes.outputs.body }}
 

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,4 +1,4 @@
-name: Version Bump
+name: Version Bump & Release
 
 on:
   pull_request:
@@ -18,6 +18,8 @@ on:
 
 permissions:
   contents: write
+  pages: write
+  id-token: write
 
 jobs:
   bump:
@@ -28,6 +30,8 @@ jobs:
         contains(github.event.pull_request.labels.*.name, 'release:minor') ||
         contains(github.event.pull_request.labels.*.name, 'release:major')))
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -79,3 +83,120 @@ jobs:
           git commit -m "🔖 v${{ steps.version.outputs.version }}"
           git tag "v${{ steps.version.outputs.version }}"
           git push origin main --tags
+
+  build:
+    needs: bump
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: v${{ needs.bump.outputs.version }}
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build
+        run: bun run build
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: |
+            dist/ltmodmenu.user.js
+            dist/ltmodmenu.meta.js
+
+  release:
+    needs: [bump, build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: v${{ needs.bump.outputs.version }}
+          fetch-depth: 0
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+
+      - name: Generate release notes
+        id: notes
+        run: |
+          CURRENT_TAG="v${{ needs.bump.outputs.version }}"
+          PREV_TAG=$(git tag --sort=-v:refname | grep -v "^${CURRENT_TAG}$" | head -1)
+
+          if [ -z "$PREV_TAG" ]; then
+            RANGE="HEAD"
+          else
+            RANGE="${PREV_TAG}..${CURRENT_TAG}"
+          fi
+
+          COMMITS=$(git log "$RANGE" --pretty=format:"%s" --no-merges)
+
+          features="" fixes="" refactors="" ui="" infra="" docs="" other=""
+
+          while IFS= read -r msg; do
+            [ -z "$msg" ] && continue
+            case "$msg" in
+              *✨*)       features+=$'\n'"- $msg" ;;
+              *🐛*|*🩹*) fixes+=$'\n'"- $msg" ;;
+              *♻️*|*🏗️*|*🔥*) refactors+=$'\n'"- $msg" ;;
+              *💄*|*🎨*) ui+=$'\n'"- $msg" ;;
+              *🔧*|*👷*|*💚*|*🙈*|*⬆️*|*⬇️*) infra+=$'\n'"- $msg" ;;
+              *📝*)       docs+=$'\n'"- $msg" ;;
+              *🔖*|*🔀*) ;; # skip version bumps and merge commits
+              *)           other+=$'\n'"- $msg" ;;
+            esac
+          done <<< "$COMMITS"
+
+          body=""
+          [ -n "$features" ]  && body+="## Features${features}"$'\n\n'
+          [ -n "$fixes" ]     && body+="## Bug Fixes${fixes}"$'\n\n'
+          [ -n "$refactors" ] && body+="## Refactoring${refactors}"$'\n\n'
+          [ -n "$ui" ]        && body+="## UI / Style${ui}"$'\n\n'
+          [ -n "$infra" ]     && body+="## Infrastructure${infra}"$'\n\n'
+          [ -n "$docs" ]      && body+="## Documentation${docs}"$'\n\n'
+          [ -n "$other" ]     && body+="## Other${other}"$'\n\n'
+
+          if [ -z "$body" ]; then
+            body="No notable changes."
+          fi
+
+          {
+            echo "body<<RELEASE_EOF"
+            echo "$body"
+            echo "RELEASE_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ needs.bump.outputs.version }}
+          files: dist/ltmodmenu.user.js
+          body: ${{ steps.notes.outputs.body }}
+
+  deploy-pages:
+    needs: [bump, build]
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+
+      - name: Upload to GitHub Pages
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- **Problem**: `version-bump.yml` pushes tags via `GITHUB_TOKEN`, which doesn't trigger `release.yml` (GitHub Actions limitation to prevent infinite loops). This is why v3.0.0 got its tag but no GitHub Release.
- **Fix**: Inline the build, release and deploy-pages jobs directly into `version-bump.yml` so everything runs in a single workflow.
- **Bonus**: Add `workflow_dispatch` to `release.yml` with a `tag` input, so missed releases (like v3.0.0) can be triggered manually.

## Test plan
- [ ] Merge this PR (no release label → only CI fix, no version bump)
- [ ] Manually dispatch "Build & Release" with tag `v3.0.0` to create the missed release
- [ ] Next PR with a `release:*` label should bump + build + release in one go

🤖 Generated with [Claude Code](https://claude.com/claude-code)